### PR TITLE
[Feat/#7] 잠금 해제 조건 달성 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.13'
+
+	// WebClient 사용을 위한 WebFlux 추가
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/capsulee_backend/capsule/controller/CapsuleController.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/controller/CapsuleController.java
@@ -5,6 +5,8 @@ import com.example.capsulee_backend.capsule.dto.response.CapsuleDetailResponseDt
 import com.example.capsulee_backend.capsule.dto.response.CreateCapsuleResponseDto;
 import com.example.capsulee_backend.capsule.dto.response.CapsuleListResponseDto;
 import com.example.capsulee_backend.capsule.service.CapsuleService;
+import com.example.capsulee_backend.weather.service.OpenWeatherService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +19,15 @@ import org.springframework.web.bind.annotation.*;
 public class CapsuleController {
 
     private final CapsuleService capsuleService;
+    private final OpenWeatherService weatherService;
 
+    @Operation(
+            summary = "캡슐 생성",
+            description = "캡슐을 생성하고, 조건과 수신자 정보를 함께 저장합니다." +
+                    "위치(LOCATION)는 '위도, 경도, 장소명'의 형식으로 작성해야 합니다" +
+                    "날씨(WEATHER)는 CLEAR | CLOUD | RAINY | SNOW 여야 합니다" +
+                    "행동(ACTION)은 자유롭게 작성해주세요"
+    )
     @PostMapping("")
     public ResponseEntity<CreateCapsuleResponseDto> createCapsule(
             Authentication authentication,
@@ -29,6 +39,10 @@ public class CapsuleController {
     }
 
     // 캡슐 목록 조회
+    @Operation(
+            summary = "캡슐 목록 조회",
+            description = "캡슐 목록을 조회합니다. type을 받습니다.(sent | received)"
+    )
     @GetMapping("")
     public ResponseEntity<CapsuleListResponseDto> getCapsules(
             Authentication authentication,
@@ -40,6 +54,10 @@ public class CapsuleController {
     }
 
     // 캡슐 상세 조회
+    @Operation(
+            summary = "캡슐 상세 조회",
+            description = "캡슐 상세 정보를 조회합니다."
+    )
     @GetMapping("/{capsuleId}")
     public ResponseEntity<CapsuleDetailResponseDto> getCapsule(
             Authentication authentication,

--- a/src/main/java/com/example/capsulee_backend/capsule/controller/ConditionController.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/controller/ConditionController.java
@@ -1,0 +1,48 @@
+package com.example.capsulee_backend.capsule.controller;
+
+import com.example.capsulee_backend.capsule.dto.request.ActionConditionRequestDto;
+import com.example.capsulee_backend.capsule.dto.request.LocationConditionRequestDto;
+import com.example.capsulee_backend.capsule.dto.response.ActionConditionResponseDto;
+import com.example.capsulee_backend.capsule.dto.response.LocationConditionResponseDto;
+import com.example.capsulee_backend.capsule.service.ConditionService;
+import com.example.capsulee_backend.config.jwt.PrincipalHandler;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ConditionController {
+
+    private final ConditionService conditionService;
+
+    @Operation(
+            summary = "조건 달성 (위치, 날씨)",
+            description = "조건(위치, 날씨) 달성 여부를 확인합니다. Ready 버튼을 활성화할 수 있는지 반환합니다." +
+                    "위치는 좌표로 줘야 합니다."
+    )
+    @PostMapping("/capsules/{capsuleId}/conditions/location")
+    public ResponseEntity<LocationConditionResponseDto> verifyLocationConditions(
+            @RequestBody LocationConditionRequestDto request
+    ) {
+        String loginID = PrincipalHandler.getLoginIDFromPrincipal();
+        return ResponseEntity.ok(conditionService.verifyLocationConditions(request, loginID));
+    }
+
+    @Operation(
+            summary = "조건 달성 (행동)",
+            description = "조건(행동) 달성 여부를 확인합니다. (true || false)"
+    )
+    @PostMapping("/capsules/{capsuleId}/conditions/action")
+    public ResponseEntity<ActionConditionResponseDto> updateActionCondition(
+            @PathVariable Long capsuleId,
+            @RequestBody ActionConditionRequestDto request
+    ) {
+        String loginID = PrincipalHandler.getLoginIDFromPrincipal();
+        return ResponseEntity.ok(conditionService.updateActionCondition(capsuleId, loginID, request));
+    }
+}

--- a/src/main/java/com/example/capsulee_backend/capsule/domain/Reception.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/domain/Reception.java
@@ -4,6 +4,7 @@ import com.example.capsulee_backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -22,6 +23,7 @@ public class Reception {
     @JoinColumn(name = "recipient_id")
     private User recipient; // 수신자 유저
 
+    @Setter
     private boolean isReady;  // 수신자의 ready 여부
 
     public Reception(Capsule capsule, User recipient) {

--- a/src/main/java/com/example/capsulee_backend/capsule/domain/RecipientConditions.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/domain/RecipientConditions.java
@@ -27,4 +27,8 @@ public class RecipientConditions {
     private Conditions condition;
 
     private boolean isAccepted; // 사용자 캡슐조건 만족 여부
+
+    public void updateStatus(boolean isAccepted) {
+        this.isAccepted = isAccepted;
+    }
 }

--- a/src/main/java/com/example/capsulee_backend/capsule/dto/request/ActionConditionRequestDto.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/dto/request/ActionConditionRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.capsulee_backend.capsule.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ActionConditionRequestDto {
+    private boolean matched;
+}

--- a/src/main/java/com/example/capsulee_backend/capsule/dto/request/LocationConditionRequestDto.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/dto/request/LocationConditionRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.capsulee_backend.capsule.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class LocationConditionRequestDto {
+
+    private Long capsuleId;
+    private Double latitude;
+    private Double longitude;
+}

--- a/src/main/java/com/example/capsulee_backend/capsule/dto/response/ActionConditionResponseDto.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/dto/response/ActionConditionResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.capsulee_backend.capsule.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ActionConditionResponseDto {
+    private Boolean isReadyAvailable;
+}

--- a/src/main/java/com/example/capsulee_backend/capsule/dto/response/CreateCapsuleResponseDto.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/dto/response/CreateCapsuleResponseDto.java
@@ -11,7 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCapsuleResponseDto {
-
+    private Long id;
     private String title;
     private String content;
     private String imageUrl;

--- a/src/main/java/com/example/capsulee_backend/capsule/dto/response/LocationConditionResponseDto.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/dto/response/LocationConditionResponseDto.java
@@ -1,0 +1,33 @@
+package com.example.capsulee_backend.capsule.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LocationConditionResponseDto {
+    private LocationResult locationCondition;
+    private WeatherResult weatherCondition;
+    private boolean isReadyAvailable;
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class LocationResult {
+        private boolean matched;
+        private double distance; // meter
+        private double userLat;  // 사용자 현재 latitude
+        private double userLon;  // 사용자 현재 longitude
+        private String conditionValue;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class WeatherResult {
+        private boolean matched;
+        private String requiredWeather;
+    }
+}

--- a/src/main/java/com/example/capsulee_backend/capsule/repository/ReceptionRepository.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/repository/ReceptionRepository.java
@@ -1,11 +1,15 @@
 package com.example.capsulee_backend.capsule.repository;
 
+import com.example.capsulee_backend.capsule.domain.Capsule;
 import com.example.capsulee_backend.capsule.domain.Reception;
 import com.example.capsulee_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReceptionRepository extends JpaRepository<Reception, Long> {
     List<Reception> findByRecipient(User currentUser);
+
+    Optional<Reception> findByCapsuleAndRecipient(Capsule capsule, User user);
 }

--- a/src/main/java/com/example/capsulee_backend/capsule/repository/RecipientConditionsRepository.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/repository/RecipientConditionsRepository.java
@@ -1,7 +1,12 @@
 package com.example.capsulee_backend.capsule.repository;
 
+import com.example.capsulee_backend.capsule.domain.Conditions;
 import com.example.capsulee_backend.capsule.domain.RecipientConditions;
+import com.example.capsulee_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RecipientConditionsRepository extends JpaRepository<RecipientConditions, Long> {
+    Optional<RecipientConditions> findByRecipientAndCondition(User user, Conditions condition);
 }

--- a/src/main/java/com/example/capsulee_backend/capsule/service/CapsuleService.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/service/CapsuleService.java
@@ -114,6 +114,7 @@ public class CapsuleService {
         }
 
         return new CreateCapsuleResponseDto(
+                savedCapsule.getId(),
                 savedCapsule.getTitle(),
                 savedCapsule.getContent(),
                 savedCapsule.getImageURL(),
@@ -204,10 +205,10 @@ public class CapsuleService {
         List<ConditionSummaryDto> conditions = new ArrayList<>();
 
         // 수신자
-        String recipients = capsule.getReceptions().stream()
-                .map(r -> r.getRecipient().getUsername())
-                .collect(Collectors.joining(", "));
-        conditions.add(new ConditionSummaryDto("RECIPIENTS", recipients));
+//        String recipients = capsule.getReceptions().stream()
+//                .map(r -> r.getRecipient().getUsername())
+//                .collect(Collectors.joining(", "));
+//        conditions.add(new ConditionSummaryDto("RECIPIENTS", recipients));
 
         // 나머지 조건들 (LOCATION, WEATHER, ACTION)
         for (Conditions condition : capsule.getCondition()) {

--- a/src/main/java/com/example/capsulee_backend/capsule/service/ConditionService.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/service/ConditionService.java
@@ -1,0 +1,141 @@
+package com.example.capsulee_backend.capsule.service;
+
+import com.example.capsulee_backend.capsule.domain.*;
+import com.example.capsulee_backend.capsule.dto.request.ActionConditionRequestDto;
+import com.example.capsulee_backend.capsule.dto.request.LocationConditionRequestDto;
+import com.example.capsulee_backend.capsule.dto.response.ActionConditionResponseDto;
+import com.example.capsulee_backend.capsule.dto.response.LocationConditionResponseDto;
+import com.example.capsulee_backend.capsule.repository.CapsuleRepository;
+import com.example.capsulee_backend.capsule.repository.ReceptionRepository;
+import com.example.capsulee_backend.capsule.repository.RecipientConditionsRepository;
+import com.example.capsulee_backend.user.domain.User;
+import com.example.capsulee_backend.user.repository.UserRepository;
+import com.example.capsulee_backend.weather.service.OpenWeatherService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ConditionService {
+
+    private final UserRepository userRepository;
+    private final CapsuleRepository capsuleRepository;
+    private final OpenWeatherService weatherService;
+    private final RecipientConditionsRepository recipientConditionsRepository;
+    private final ReceptionRepository receptionRepository;
+
+    @Transactional
+    public LocationConditionResponseDto verifyLocationConditions(
+            LocationConditionRequestDto request, String loginID
+    ) {
+        User user = userRepository.findByLoginID(loginID)
+                .orElseThrow(() -> new EntityNotFoundException("[ERROR] 유저를 찾을 수 없습니다."));
+
+        Capsule capsule = capsuleRepository.findById(request.getCapsuleId())
+                .orElseThrow(() -> new EntityNotFoundException("[ERROR] 캡슐을 찾을 수 없습니다."));
+
+        // 캡슐 잠금 조건
+        List<Conditions> conditions = capsule.getCondition();
+
+        // 사용자의 위치
+        double userLat = request.getLatitude();
+        double userLon = request.getLongitude();
+
+        LocationConditionResponseDto.LocationResult locationResult = null;
+        LocationConditionResponseDto.WeatherResult weatherResult = null;
+
+        // LOCATION 조건 확인
+        Optional<Conditions> locationConditionOpt = conditions.stream()
+                .filter(c -> c.getType() == ConditionType.LOCATION)
+                .findFirst();
+
+        // LOCATION 조건이 있다면
+        if (locationConditionOpt.isPresent()) {
+            Conditions locationCondition = locationConditionOpt.get();
+            String targetValue = locationCondition.getValue();
+
+            String[] parts = targetValue.split(",");
+            double targetLat = Double.parseDouble(parts[0]);
+            double targetLon = Double.parseDouble(parts[1]);
+            String conditionValue = parts[2];
+
+            double distance = calculateDistance(targetLat, targetLon, userLat, userLon);  // m 기준
+            boolean isMatched = distance <= 100;
+
+            locationResult = new LocationConditionResponseDto.LocationResult(
+                    isMatched, distance, userLat, userLon, conditionValue
+            );
+
+            RecipientConditions rc = recipientConditionsRepository.findByRecipientAndCondition(user, locationCondition)
+                    .orElseThrow(() -> new RuntimeException("[ERROR] 조건 매핑이 없습니다."));
+            rc.updateStatus(isMatched);   // 조건 상태 저장
+        }
+
+        // WEATHER 조건 확인
+        Optional<Conditions> weatherConditionOpt = conditions.stream()
+                .filter(c -> c.getType() == ConditionType.WEATHER)
+                .findFirst();
+
+        // WEATHER 조건이 있다면
+        if (weatherConditionOpt.isPresent()) {
+            Conditions weatherCondition = weatherConditionOpt.get();
+            String targetWeather = weatherCondition.getValue();
+
+            boolean isMatched = weatherService.checkWeatherCondition(userLat, userLon, targetWeather);
+
+            weatherResult = new LocationConditionResponseDto.WeatherResult(
+                    isMatched, targetWeather
+            );
+
+            RecipientConditions rc = recipientConditionsRepository.findByRecipientAndCondition(user, weatherCondition)
+                    .orElseThrow(() -> new RuntimeException("[ERROR] 조건 매핑이 없습니다."));
+            rc.updateStatus(isMatched);  // 해당 조건 isAccepted = true로 변경
+        }
+
+        List<RecipientConditions> recipientConditionsList = conditions.stream()
+                .map(condition -> recipientConditionsRepository.findByRecipientAndCondition(user, condition)
+                        .orElse(null))  // null로 처리해서 필터링
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (recipientConditionsList.size() != conditions.size()) {
+            throw new RuntimeException("[ERROR] 일부 조건에 대한 매핑 정보가 없습니다.");
+        }
+
+        for (RecipientConditions rc : recipientConditionsList) {
+            System.out.printf("✔️ 조건 타입: %s | 만족 여부: %s\n", rc.getCondition().getType(), rc.isAccepted());
+        }
+
+        boolean isReadyAvailable = recipientConditionsList.stream()
+                .allMatch(RecipientConditions::isAccepted);
+
+        // 수신 정보 상태 변경 (Ready 버튼 활성화 / 비활성화)
+        Reception reception = receptionRepository.findByCapsuleAndRecipient(capsule, user)
+                .orElseThrow(() -> new RuntimeException("[ERROR] 수신자 정보를 찾을 수 없습니다."));
+        reception.setReady(isReadyAvailable);
+
+        return new LocationConditionResponseDto(locationResult, weatherResult, isReadyAvailable);
+    }
+
+    private double calculateDistance(double targetLat, double targetLon, double userLat, double userLon) {
+        double R = 6371e3; // m
+        double userRad1 = Math.toRadians(userLat);
+        double userRad2 = Math.toRadians(userLon);
+        double diffRad1 = Math.toRadians(targetLat - userLat);
+        double diffRad2 = Math.toRadians(targetLon - userLon);
+
+        double a = Math.sin(diffRad1 / 2) * Math.sin(diffRad1 / 2) +
+                Math.cos(userRad1) * Math.cos(userRad2) *
+                        Math.sin(diffRad2 / 2) * Math.sin(diffRad2 / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c; // return m
+    }
+
+}

--- a/src/main/java/com/example/capsulee_backend/capsule/service/ConditionService.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/service/ConditionService.java
@@ -138,4 +138,50 @@ public class ConditionService {
         return R * c; // return m
     }
 
+    @Transactional
+    public ActionConditionResponseDto updateActionCondition(Long capsuleId, String loginID, ActionConditionRequestDto request) {
+        Capsule capsule = capsuleRepository.findById(capsuleId)
+                .orElseThrow(() -> new EntityNotFoundException("[ERROR] 캡슐을 찾을 수 없습니다."));
+
+        User user = userRepository.findByLoginID(loginID)
+                .orElseThrow(() -> new EntityNotFoundException("[ERROR] 사용자를 찾을 수 없습니다."));
+
+        // 캡슐 잠금 조건
+        List<Conditions> conditions = capsule.getCondition();
+
+        // 행동 조건이 있는지 확인
+        Optional<Conditions> actionConditionOpt = conditions.stream()
+                .filter(c -> c.getType() == ConditionType.ACTION)
+                .findFirst();
+
+        // 행동 조건이 있다면
+        if (actionConditionOpt.isPresent()) {
+            Conditions actionCondition = actionConditionOpt.get();
+
+            RecipientConditions rc = recipientConditionsRepository.findByRecipientAndCondition(user, actionCondition)
+                    .orElseThrow(() -> new RuntimeException("[ERROR] 조건 매핑이 없습니다."));
+
+            rc.updateStatus(request.isMatched());
+        }
+
+        List<RecipientConditions> recipientConditionsList = conditions.stream()
+                .map(condition -> recipientConditionsRepository.findByRecipientAndCondition(user, condition)
+                        .orElse(null))  // null로 처리해서 필터링
+                .filter(Objects::nonNull)
+                .toList();
+
+        if (recipientConditionsList.size() != conditions.size()) {
+            throw new RuntimeException("[ERROR] 일부 조건에 대한 매핑 정보가 없습니다.");
+        }
+
+        boolean isReadyAvailable = recipientConditionsList.stream()
+                .allMatch(RecipientConditions::isAccepted);
+
+        Reception reception = receptionRepository.findByCapsuleAndRecipient(capsule, user)
+                .orElseThrow(() -> new RuntimeException("[ERROR] 수신자 정보를 찾을 수 없습니다."));
+
+        reception.setReady(isReadyAvailable);
+
+        return new ActionConditionResponseDto(isReadyAvailable);
+    }
 }

--- a/src/main/java/com/example/capsulee_backend/config/OpenWeatherConfig.java
+++ b/src/main/java/com/example/capsulee_backend/config/OpenWeatherConfig.java
@@ -1,0 +1,16 @@
+package com.example.capsulee_backend.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class OpenWeatherConfig {
+
+    @Value("${openweatherapi.api.key}")
+    private String key;
+
+    @Value("${openweatherapi.api.base-url}")
+    private String baseUrl;
+}

--- a/src/main/java/com/example/capsulee_backend/config/WebClientConfig.java
+++ b/src/main/java/com/example/capsulee_backend/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.example.capsulee_backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/com/example/capsulee_backend/weather/dto/response/OpenWeatherResponse.java
+++ b/src/main/java/com/example/capsulee_backend/weather/dto/response/OpenWeatherResponse.java
@@ -1,0 +1,17 @@
+package com.example.capsulee_backend.weather.dto.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class OpenWeatherResponse {
+
+    private List<Weather> weather;
+
+    @Data
+    public static class Weather {
+        private String main;        // Clear, Clouds, Rain, Snow ...
+        private String description; // scattered clouds, light rain 등
+    }
+}

--- a/src/main/java/com/example/capsulee_backend/weather/service/OpenWeatherService.java
+++ b/src/main/java/com/example/capsulee_backend/weather/service/OpenWeatherService.java
@@ -1,0 +1,72 @@
+package com.example.capsulee_backend.weather.service;
+
+import com.example.capsulee_backend.config.OpenWeatherConfig;
+import com.example.capsulee_backend.weather.dto.response.OpenWeatherResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class OpenWeatherService {
+
+    private final WebClient.Builder webClientBuilder;
+    private final OpenWeatherConfig config; // API KEY, BASE_URL 저장
+
+    /**
+     * 지정된 위경도(lat, lon)의 현재 날씨를 조회하고
+     * targetCondition(CLEAR, CLOUD, RAINY, SNOW)과 비교하여 충족 여부 반환
+     */
+    public boolean checkWeatherCondition(double lat, double lon, String targetCondition) {
+
+        String url = String.format(
+                "%s/weather?lat=%f&lon=%f&appid=%s&units=metric",
+                config.getBaseUrl(),
+                lat,
+                lon,
+                config.getKey()
+        );
+
+        // OpenWeather API 호출
+        OpenWeatherResponse response = webClientBuilder.build()
+                .get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(OpenWeatherResponse.class)
+                .block();
+
+        if (response == null || response.getWeather() == null || response.getWeather().isEmpty()) {
+            throw new RuntimeException("[ERROR] OpenWeather API 응답 없음 또는 파싱 실패");
+        }
+
+        // 현재 날씨 코드(main 값: Clear, Clouds, Rain, Snow ...)
+        String currentWeather = response.getWeather().get(0).getMain().toUpperCase();
+        String description = response.getWeather().get(0).getDescription();
+
+        System.out.println("🌤 [현재 날씨] main=" + currentWeather + ", desc=" + description);
+
+        // 조건 비교
+        switch (targetCondition.toUpperCase()) {
+
+            case "CLEAR":
+                return currentWeather.equals("CLEAR");
+
+            case "CLOUD":
+                // Clouds / Overcast 포함
+                return currentWeather.equals("CLOUDS") || currentWeather.equals("OVERCAST");
+
+            case "RAINY":
+                // Drizzle, Thunderstorm 포함
+                return currentWeather.equals("RAIN")
+                        || currentWeather.equals("DRIZZLE")
+                        || currentWeather.equals("THUNDERSTORM");
+
+            case "SNOW":
+                return currentWeather.equals("SNOW");
+
+            default:
+                System.out.println("⚠️ 지원하지 않는 weather 조건: " + targetCondition);
+                return false;
+        }
+    }
+}

--- a/src/main/java/com/example/capsulee_backend/weather/util/WeatherTimeUtil.java
+++ b/src/main/java/com/example/capsulee_backend/weather/util/WeatherTimeUtil.java
@@ -1,0 +1,73 @@
+package com.example.capsulee_backend.weather.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class WeatherTimeUtil {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final DateTimeFormatter HOUR_FORMATTER = DateTimeFormatter.ofPattern("HH");
+    private static final int API_UPDATE_MINUTE = 40;  // 공식 기준: 매시간 40분에 갱신됨
+
+    /**
+     * 기준 시간(base_time)을 계산 (HH00)
+     * 예) 15:32 → 1400, 15:45 → 1500
+     */
+    public static String getBaseTime() {
+        LocalDateTime now = LocalDateTime.now();
+
+        LocalDateTime baseDateTime =
+                (now.getMinute() < API_UPDATE_MINUTE)
+                        ? now.minusHours(1)
+                        : now;
+
+        return baseDateTime.format(HOUR_FORMATTER) + "00";
+    }
+
+    /**
+     * 기준 날짜(base_date)를 계산 (YYYYMMDD)
+     * baseTime이 전날 기준(예: 2300)으로 바뀌는 경우 처리
+     */
+    public static String getBaseDate(String baseTime) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // baseTime을 숫자로 변환 (예: "2300" → 23)
+        int baseHour = Integer.parseInt(baseTime.substring(0, 2));
+
+        // 현재 시간이 00시이고 baseTime이 23시이면 날짜는 전날
+        if (now.getHour() == 0 && baseHour == 23) {
+            return now.minusDays(1).format(DATE_FORMATTER);
+        }
+
+        return now.format(DATE_FORMATTER);
+    }
+
+    /**
+     * 이전 기준 시간 계산
+     * 예) 1500 → 1400, 0000 → 전날 2300
+     */
+    public static String getPreviousBaseTime(String currentBaseTime, int hoursBack) {
+        int hour = Integer.parseInt(currentBaseTime.substring(0, 2));
+        int prevHour = hour - hoursBack;
+        if (prevHour < 0) prevHour += 24;
+        return String.format("%02d00", prevHour);
+    }
+
+    /**
+     * fallback에서 날짜 조정
+     * 예) baseTime=0000 → previous=2300인 경우 날짜는 -1
+     */
+    public static String adjustDateIfNeeded(String baseDate, String currentTime, String fallbackTime) {
+        int curHour = Integer.parseInt(currentTime.substring(0, 2));
+        int fbHour = Integer.parseInt(fallbackTime.substring(0, 2));
+
+        // fallbackTime(23시) > currentTime(00시) → 날짜 -1
+        if (fbHour > curHour) {
+            LocalDate date = LocalDate.parse(baseDate, DATE_FORMATTER);
+            return date.minusDays(1).format(DATE_FORMATTER);
+        }
+
+        return baseDate;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,8 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: update
+openweatherapi:
+  config:
+    import: "classpath:SECRET.yml"
+  api:
+    base-url: https://api.openweathermap.org/data/2.5


### PR DESCRIPTION
<!-- [제목] title ex) [feat] 소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #7 

---


## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->

1. 날씨 API 연결
- 초기 기상청 API를 연결하였으나, 제대로 된 응답이 불러와지지 않아 OpenWeatherAPI를 연결했습니다.


2. 캡슐 생성 API 수정
- Response에 캡슐 id를 추가했습니다.


3. 캡슐 목록 조회 응답 구조 수정
- 응답에서 수신자 목록을 제거했습니다.


4. 위치&냘씨 조건 달성 API 구현
- 현재 위치 (위도, 경도)를 request로 받으면
- 위치, 날씨 조건 확인 (존재할 경우)
- 일치할 경우 condition 조건 상태 update 
- ready 가능 여부 확인 후 update
- condition 만족 여부, ready 가능 여부 반환


5. 행동 조건 달성 API 구현
- 프론트에서 true | false request로 받으면
- 행동 조건 상태 update
- ready 가능 여부 확인 후 update
- ready 가능 여부 반환



??? 지금 ConditionService,... 이런 식으로 쓰고 있는데 Unlock으로 수정할까요?

---

## 📌스크린샷 (선택)
