### PR TITLE
[Feat/#18] 모든 사용자의 리스트 반환하는 API 추가

### DIFF
--- a/src/main/java/com/example/capsulee_backend/user/controller/UserController.java
+++ b/src/main/java/com/example/capsulee_backend/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.example.capsulee_backend.user.controller;
 import com.example.capsulee_backend.config.jwt.PrincipalHandler;
 import com.example.capsulee_backend.user.domain.User;
 import com.example.capsulee_backend.user.dto.request.UserUpdateRequestDto;
+import com.example.capsulee_backend.user.dto.response.OtherUserInfoResponseDto;
 import com.example.capsulee_backend.user.dto.response.UserInfoResponseDto;
 import com.example.capsulee_backend.user.dto.response.UserSearchResponseDto;
 import com.example.capsulee_backend.user.dto.response.UserUpdateResponseDto;
@@ -10,6 +11,8 @@ import com.example.capsulee_backend.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,5 +48,16 @@ public class UserController {
         }
         // 유저가 있으면
         return ResponseEntity.ok(new UserSearchResponseDto(user.getLoginID(), user.getUsername()));
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<OtherUserInfoResponseDto>> getAllOtherUserInfo() {
+        // 토큰에서 내 정보 가져오기
+        String userLoginID = PrincipalHandler.getLoginIDFromPrincipal();
+        User user = userService.getUserByLoginID(userLoginID);
+
+        // 모든 사용자 정보 가져오기
+        List<OtherUserInfoResponseDto> allOtherUserInfo = userService.getAllOtherUserInfo(user);
+        return ResponseEntity.ok(allOtherUserInfo);
     }
 }

--- a/src/main/java/com/example/capsulee_backend/user/dto/response/OtherUserInfoResponseDto.java
+++ b/src/main/java/com/example/capsulee_backend/user/dto/response/OtherUserInfoResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.capsulee_backend.user.dto.response;
+
+import com.example.capsulee_backend.user.domain.FriendRequest;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OtherUserInfoResponseDto {
+    private Long id;
+    private String loginID;
+    private String username;
+    private FriendRequest status;
+}

--- a/src/main/java/com/example/capsulee_backend/user/service/UserService.java
+++ b/src/main/java/com/example/capsulee_backend/user/service/UserService.java
@@ -3,14 +3,13 @@ package com.example.capsulee_backend.user.service;
 import com.example.capsulee_backend.capsule.domain.Reception;
 import com.example.capsulee_backend.capsule.repository.ReceptionRepository;
 import com.example.capsulee_backend.config.jwt.JwtTokenProvider;
+import com.example.capsulee_backend.user.domain.FriendRequest;
+import com.example.capsulee_backend.user.domain.FriendShip;
 import com.example.capsulee_backend.user.domain.User;
 import com.example.capsulee_backend.user.dto.request.JoinRequestDto;
 import com.example.capsulee_backend.user.dto.request.LoginRequestDto;
 import com.example.capsulee_backend.user.dto.request.UserUpdateRequestDto;
-import com.example.capsulee_backend.user.dto.response.LoginResponseDto;
-import com.example.capsulee_backend.user.dto.response.UserInfoResponseDto;
-import com.example.capsulee_backend.user.dto.response.UserStatResponseDto;
-import com.example.capsulee_backend.user.dto.response.UserUpdateResponseDto;
+import com.example.capsulee_backend.user.dto.response.*;
 import com.example.capsulee_backend.user.repository.FriendShipRepository;
 import com.example.capsulee_backend.user.repository.UserRepository;
 import lombok.AllArgsConstructor;
@@ -18,6 +17,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -112,5 +112,30 @@ public class UserService {
         user.update(requestDto.getLoginID(), requestDto.getUsername());
 
         return new UserUpdateResponseDto(user.getLoginID(), user.getUsername());
+    }
+
+    public List<OtherUserInfoResponseDto> getAllOtherUserInfo(User user) {
+        List<OtherUserInfoResponseDto> otherUserInfoResponseDtoList = new ArrayList<>();
+
+        // 모든 유저 조회
+        List<User> allOtherUsers = userRepository.findAll();
+        for (User otherUser : allOtherUsers) {
+            // 친구 요청 보낸 적 있는 경우
+            if (friendShipRepository.existsBySenderAndReceiver(user, otherUser)) {
+                FriendShip friendShip = friendShipRepository.findBySenderAndReceiver(user, otherUser);
+                otherUserInfoResponseDtoList.add(new OtherUserInfoResponseDto(otherUser.getId(), otherUser.getLoginID(), otherUser.getUsername(), friendShip.getStatus()));
+            }
+            // 친구 요청 받은 적 있는 경우
+            else if (friendShipRepository.existsBySenderAndReceiver(otherUser, user)) {
+                FriendShip friendShip = friendShipRepository.findBySenderAndReceiver(otherUser, user);
+                otherUserInfoResponseDtoList.add(new OtherUserInfoResponseDto(otherUser.getId(), otherUser.getLoginID(), otherUser.getUsername(), friendShip.getStatus()));
+            }
+            // 아무런 친구 요청이 없었던 경우
+            else {
+                otherUserInfoResponseDtoList.add(new OtherUserInfoResponseDto(otherUser.getId(), otherUser.getLoginID(), otherUser.getUsername(), null));
+            }
+        }
+
+        return otherUserInfoResponseDtoList;
     }
 }


### PR DESCRIPTION
<!-- [제목] title ex) [feat] 소셜 로그인 기능 추가 -->
모든 사용자의 리스트 반환하는 API 추가

## 해당 이슈 번호

closed #18 

---


## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->
- 모든 사용자의 리스트 반환하는 API 추가
- 각 사용자의 아이디, 로그인아이디, 닉네임, 친구 여부 정보가 있어야 함

---

## 📌스크린샷 (선택)
