### PR TITLE
[Feat/#24] 가장 임박한 캡슐 상세 조회 API 추가

### DIFF
--- a/src/main/java/com/example/capsulee_backend/capsule/controller/CapsuleController.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/controller/CapsuleController.java
@@ -70,4 +70,13 @@ public class CapsuleController {
         CapsuleDetailResponseDto capsuleDetail = capsuleService.getCapsule(loginID, capsuleId);
         return ResponseEntity.status(HttpStatus.OK).body(capsuleDetail);
     }
+    @GetMapping("/home")
+    public ResponseEntity<CapsuleDetailResponseDto> getLatestCapsule(
+            Authentication authentication
+    ) {
+        String loginID = authentication.getName();
+        Long capsuleId = capsuleService.getLatestCapsuleId(loginID);
+        CapsuleDetailResponseDto capsuleDetail = capsuleService.getCapsule(loginID, capsuleId);
+        return ResponseEntity.status(HttpStatus.OK).body(capsuleDetail);
+    }
 }

--- a/src/main/java/com/example/capsulee_backend/capsule/repository/CapsuleRepository.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/repository/CapsuleRepository.java
@@ -4,8 +4,11 @@ import com.example.capsulee_backend.capsule.domain.Capsule;
 import com.example.capsulee_backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface CapsuleRepository extends JpaRepository<Capsule, Long> {
     List<Capsule> findByCreatorOrderByOpenTimeDesc(User creator);
+    Optional<Capsule> findTopByCreatorAndOpenTimeAfterOrderByOpenTimeAsc(User creator, LocalDateTime now);
 }

--- a/src/main/java/com/example/capsulee_backend/capsule/service/CapsuleService.java
+++ b/src/main/java/com/example/capsulee_backend/capsule/service/CapsuleService.java
@@ -329,6 +329,22 @@ public class CapsuleService {
         );
     }
 
+    public Long getLatestCapsuleId(String loginID) {
+        User user = userRepository.findByLoginID(loginID)
+                .orElseThrow(() -> new EntityNotFoundException("[ERROR] 유저를 찾을 수 없습니다."));
+
+        // 해당 유저가 가진 캡슐 중, open 날짜가 가장 가까운 캡슐을 반환
+        LocalDateTime now = LocalDateTime.now(); // 현재 시간보다는 뒤여야 함
+        Capsule latestCapsule = capsuleRepository
+                .findTopByCreatorAndOpenTimeAfterOrderByOpenTimeAsc(user, now)
+                .orElse(null);
+        if (latestCapsule == null) {
+            // 아직 캡슐이 하나도 없는 경우
+            return null;
+        }
+        return latestCapsule.getId(); // capsule의 id 반환
+    }
+
     private int calculateProgressPercent(LocalDateTime createdAt, LocalDateTime openTime) {
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/example/capsulee_backend/user/service/UserService.java
+++ b/src/main/java/com/example/capsulee_backend/user/service/UserService.java
@@ -91,8 +91,27 @@ public class UserService {
 
         // 친구 수
         int friends = 0;
-        friends += friendShipRepository.countByReceiver(user);
-        friends += friendShipRepository.countBySender(user);
+        // 해당 유저가 친구 신청을 한 경우
+        List<FriendShip> sendFriendShip = friendShipRepository.findAllBySender(user);
+        for (FriendShip friendShip : sendFriendShip) {
+            if (friendShip.getStatus().equals(FriendRequest.ACCEPTED)) {
+                // 친구 요청을 accept한 경우에만 친구 상태
+                friends++;
+            }
+        }
+
+        // 해당 유저가 친구 신청을 받은 경우
+        List<FriendShip> receiveFriendShip = friendShipRepository.findAllByReceiver(user);
+        for (FriendShip friendShip : receiveFriendShip) {
+            if (friendShip.getStatus().equals(FriendRequest.ACCEPTED)) {
+                // 친구 요청을 accept한 경우에만 친구 상태
+                User friend = friendShip.getSender();
+                FriendAcceptedInfoResponseDto friendAcceptedInfoResponseDto = new FriendAcceptedInfoResponseDto(
+                        friendShip.getId(), friend.getId(), friend.getLoginID(), friend.getUsername()
+                );
+                friends++;
+            }
+        }
 
         return new UserStatResponseDto(totals, opened, friends);
     }


### PR DESCRIPTION
<!-- [제목] title ex) [feat] 소셜 로그인 기능 추가 -->
가장 임박한 캡슐 상세 조회 API 추가

## 해당 이슈 번호

closed #24 

---


## 💎 PR Point
<!-- 해당 PR의 주요 내용 적기 -->
- 가장 임박한 캡슐 상세 조회 API 추가
- 사용자 정보 조회 때 친구인 경우만 카운트되도록 API 수정

---

## 📌스크린샷 (선택)
